### PR TITLE
Minor fixes

### DIFF
--- a/src/elements/actions/Delete.php
+++ b/src/elements/actions/Delete.php
@@ -84,7 +84,7 @@ class Delete extends ElementAction
 						onSubmit: function() {
 							Craft.elementIndex.submitAction(
 								$type,
-								Garnish.getPostData(modal.;\$container;)
+								Garnish.getPostData(modal.\$container)
 							)
 							modal.hide();
 							

--- a/src/elements/actions/Delete.php
+++ b/src/elements/actions/Delete.php
@@ -64,7 +64,7 @@ class Delete extends ElementAction
 	new Craft.ElementActionTrigger({
 		type: $type,
 		batch: true,
-		validateSelection;: function () {
+		validateSelection: function () {
 			return true;
 		},
 		activate: function (selectedItems) {

--- a/src/elements/actions/Delete.php
+++ b/src/elements/actions/Delete.php
@@ -63,7 +63,7 @@ class Delete extends ElementAction
 !function () {
 	new Craft.ElementActionTrigger({
 		type: $type,
-		batch;: true,
+		batch: true,
 		validateSelection;: function () {
 			return true;
 		},

--- a/src/web/assets/DeleteTagModal.js
+++ b/src/web/assets/DeleteTagModal.js
@@ -94,7 +94,7 @@ Craft.DeleteTagModal = Garnish.Modal.extend({
 		this.userSelect = new Craft.BaseElementSelectInput({
 			id: 'replaceselect' + this.id,
 			name: 'replaceWith',
-			elementType: 'ether\\tagManager\\Elements\\Tag',
+			elementType: 'ether\\tagManager\\elements\\Tag',
 			criteria: {
 				id: idParam,
 			},


### PR DESCRIPTION
Thank you for all your efforts in making and maintaining this plugin.

This PR removes a few odd semicolons that were sources of `Uncaught SyntaxErrors` (Unexpected token ;) in my setup.

Also it changes "Elements" to "elements" in the class name. Though not an issue on your typical local dev mac, I think this might resolve #5 in case sensitive environments.

Thanks!