### PR TITLE
Fixing issue 18, tags not appearing after craftcms/cms@636f778

### DIFF
--- a/src/elements/db/TagQuery.php
+++ b/src/elements/db/TagQuery.php
@@ -23,6 +23,15 @@ class TagQuery extends \craft\elements\db\TagQuery
 
 	protected function afterPrepare (): bool
 	{
+		// due to the introduction of type filtering in element queries (see:https://github.com/craftcms/cms/discussions/9806)
+		// we have to make sure that the query is filtering based on 'craft\elements\Tag' and not 'ether\tagManager\elements\Tag'
+		for($i = 0; $i <= count($this->subQuery->where); $i++) {
+			if( !empty($this->subQuery->where[$i]['elements.type']) ) { 
+				$this->subQuery->where[$i]['elements.type'] = 'craft\elements\Tag';
+				break;
+			}
+		}
+
 		if (Craft::$app->getDb()->getDriverName() === 'mysql')
 			return parent::afterPrepare();
 


### PR DESCRIPTION
Not 100% sure if this is _the right way_ to fix the issue, but this gets the job done given the recent element type filtering introduced in craftcms/cms@636f778

Hopefully it's at least a road map toward a more elegant solution.

Resolves #18 