### PR TITLE
fixed cache issues on element index page 

### DIFF
--- a/src/TagManager.php
+++ b/src/TagManager.php
@@ -13,6 +13,8 @@ use craft\base\Element;
 use craft\base\Model;
 use craft\base\Plugin;
 use craft\elements\actions\Edit;
+use craft\elements\Tag as CraftTagElement;
+use craft\events\ModelEvent;
 use craft\events\RegisterCpNavItemsEvent;
 use craft\events\RegisterElementActionsEvent;
 use craft\events\RegisterUrlRulesEvent;
@@ -82,7 +84,14 @@ class TagManager extends Plugin
 				[$this, 'onRegisterIgnoredTypes']
 			);
 		}
-
+		
+		Event::on(
+			CraftTagElement::class,
+			CraftTagElement::EVENT_AFTER_SAVE,
+			function (ModelEvent $event) {
+				Craft::$app->elements->invalidateCachesForElementType(Tag::class);
+			}
+		);
 	}
 
 	// Craft


### PR DESCRIPTION
fixed https://github.com/ethercreative/tags/issues/21 and https://github.com/ethercreative/tags/issues/18

for custom element types, Craft manages and invalidates element index cache on adding or editing an element -i believe element index cache is related to 3.7.14-. but when you add or edit a tag via element index page or even tag field on entry page, Craft is not aware of this plugin's tag element type so this PR invalidate element type cache for this plugin on after save tag event
