### PR TITLE
Set initial property values to null to avoid export errors

### DIFF
--- a/src/elements/Tag.php
+++ b/src/elements/Tag.php
@@ -30,8 +30,8 @@ class Tag extends \craft\elements\Tag
 	// =========================================================================
 
 	/** @var Tag|null */
-	public ?Tag $replaceWith;
-	public ?int $usage;
+	public ?Tag $replaceWith = null;
+	public ?int $usage = null;
 
 	// Methods
 	// =========================================================================


### PR DESCRIPTION
Updated Tag.php to set initial properties to null.

Without this, a server error is encountered when exporting Tags in the back end using the "Expanded" exporter.